### PR TITLE
Fixes that buku hangs when launched from some window managers that don't set up a stdin

### DIFF
--- a/rofi-buku
+++ b/rofi-buku
@@ -50,7 +50,7 @@ Use <span color='${help_color}'>${switch_view}</span> to switch View. <span colo
         content=$(parseBuku)
         menu=$(echo "${content}" | _rofi -p '> ' -filter "${filter}" -mesg "${HELP}" -kb-custom-1 "${new_bookmark}" -kb-custom-2 "${switch_view}" -kb-custom-3 "${actions}" -kb-custom-4 "${edit}" -kb-custom-5 "${delete}")
     elif [[ $mode == "tags" ]]; then
-        menu=$(buku --np --st | grep -v -e '^waiting for input$' -e '^$' | awk '{$NF=""; print $0}' | cut -d ' ' -f2  | _rofi -p '> ' -mesg "${HELP}" -kb-custom-1 "${new_bookmark}" -kb-custom-2 "${switch_view}" -kb-custom-3 "${actions}" -kb-custom-4 "${edit}" -kb-custom-5 "${delete}")
+        menu=$(buku --nostdin --np --st | grep -v -e '^waiting for input$' -e '^$' | awk '{$NF=""; print $0}' | cut -d ' ' -f2  | _rofi -p '> ' -mesg "${HELP}" -kb-custom-1 "${new_bookmark}" -kb-custom-2 "${switch_view}" -kb-custom-3 "${actions}" -kb-custom-4 "${edit}" -kb-custom-5 "${delete}")
     fi
     val=$?
     if [[ $val -eq 1 ]]; then
@@ -75,7 +75,7 @@ Use <span color='${help_color}'>${switch_view}</span> to switch View. <span colo
         if [[ $mode == "bookmarks" ]]; then
             id=$(getId "$content" "$menu")
             for bm in ${id}; do
-                buku -o "${bm}"
+                buku --nostdin -o "${bm}"
             done
         elif [[ $mode == "tags" ]]; then
             filter="${menu}" mode="bookmarks" main
@@ -120,7 +120,7 @@ optionsMenu () {
           if [[ $newtag == "" ]]; then
             mode=tags main
           else
-            buku --replace "${menu}" "${newtag}"
+            buku --nostdin --replace "${menu}" "${newtag}"
             mode=tags main
           fi
         fi
@@ -132,7 +132,7 @@ optionsMenu () {
           exit
         elif [[ $val -eq 0 ]]; then
           if [[ $delask == "1. Yes" ]]; then
-	    echo y | script -qfc "buku --replace ${menu}" /dev/null
+	    echo y | script -qfc "buku --nostdin --replace ${menu}" /dev/null
             mode=tags main
           elif [[ $delask == "2. No" ]]; then
             mode=tags main
@@ -153,7 +153,7 @@ deleteMenu () {
     exit
   elif [[ $val -eq 0 ]]; then
     if [[ $delask == "1. Yes" ]]; then
-      buku -d "${id}" --tacit
+      buku --nostdin -d "${id}" --tacit
       mode=bookmarks main
     elif [[ $delask == "2. No" ]]; then
       optionsMenu
@@ -197,7 +197,7 @@ editTitle () {
   if [[ $val -eq 1 ]]; then
     exit
   elif [[ $val -eq 0 ]]; then
-    buku -u "${id}" --title "${titlemenu}"
+    buku --nostdin -u "${id}" --title "${titlemenu}"
   fi
 
   mode=bookmarks main
@@ -214,7 +214,7 @@ editUrl () {
       echo "" | rofi -e "Not a valid URI, Make sure URLs start with http"
       editUrl
     else
-      buku -u "${id}" --url "${urlmenu}"
+      buku --nostdin -u "${id}" --url "${urlmenu}"
     fi
   fi
 
@@ -228,7 +228,7 @@ editComment () {
   if [[ $val -eq 1 ]]; then
     exit
   elif [[ $val -eq 0 ]]; then
-    buku -u "${id}" --comment "${commentmenu}"
+    buku --nostdin -u "${id}" --comment "${commentmenu}"
   fi
 
   mode=bookmarks main
@@ -241,7 +241,7 @@ editTags () {
   if [[ $val -eq 1 ]]; then
     exit
   elif [[ $val -eq 0 ]]; then
-    buku -u "${id}" --tag "${edittagsmenu}"
+    buku --nostdin -u "${id}" --tag "${edittagsmenu}"
   fi
 
   mode=bookmarks main
@@ -259,7 +259,7 @@ addMark () {
 }
 
 addTags () {
-  inserttags=$(buku --np --st | grep -v '^waiting for input$' | awk '{$NF=""; print $0}' | cut -d ' ' -f2- | _rofi -p '> ' -mesg "Add some tags. Separate tags with ', '")
+  inserttags=$(buku --nostdin --np --st | grep -v '^waiting for input$' | awk '{$NF=""; print $0}' | cut -d ' ' -f2- | _rofi -p '> ' -mesg "Add some tags. Separate tags with ', '")
   val=$?
 
   if [[ $val -eq 1 ]]; then
@@ -275,12 +275,12 @@ addTags () {
       tags=${inserttags}
     fi
 
-    buku -a "${inserturl}" "${tags}"
+    buku --nostdin -a "${inserturl}" "${tags}"
   fi
 }
 
 parseBuku () {
-  buku --nc -p | grep -v '^waiting for input$' | gawk -v max="$max_str_width" -v type="$display_type" '
+  buku --nostdin --nc -p | grep -v '^waiting for input$' | gawk -v max="$max_str_width" -v type="$display_type" '
     BEGIN { RS=""; FS="\n" }
     {
       id = gensub(/([0-9]+)\.(.*)/, "\\1", "g", $1)
@@ -331,7 +331,7 @@ getId () {
 }
 
 getTitleFromId () {
-  buku --nc -p "${1}" | grep -v '^waiting for input$' | gawk '
+  buku --nostdin --nc -p "${1}" | grep -v '^waiting for input$' | gawk '
     BEGIN { RS=""; FS="\n" }
 
     { print gensub(/[0-9]+\.\s*(.*)/, "\\1", "g", $1) }
@@ -339,7 +339,7 @@ getTitleFromId () {
 }
 
 getUrlFromId () {
-  buku --nc -p "${1}" | grep -v '^waiting for input$' | gawk '
+  buku --nostdin --nc -p "${1}" | grep -v '^waiting for input$' | gawk '
     BEGIN { RS=""; FS="\n" }
 
     { print gensub(/\s+> (.*)/, "\\1", "g", $2) }
@@ -347,7 +347,7 @@ getUrlFromId () {
 }
 
 getCommentFromId () {
-  buku --nc -p "${1}" | grep -v '^waiting for input$' | gawk '
+  buku --nostdin --nc -p "${1}" | grep -v '^waiting for input$' | gawk '
     BEGIN { RS=""; FS="\n" }
 
     {
@@ -358,7 +358,7 @@ getCommentFromId () {
 }
 
 getTagsFromId () {
-  buku --nc -p "${1}" | grep -v '^waiting for input$' | gawk '
+  buku --nostdin --nc -p "${1}" | grep -v '^waiting for input$' | gawk '
     BEGIN { RS=""; FS="\n" }
 
     {


### PR DESCRIPTION
At least, that's what I suspect the problem is, since adding the `--nostdin` argument to the buku calls fixes the issue. Without it, gdb says the hung process is waiting on a `read()`.

I'm not certain that all code paths need the argument, but it is probable, and doesn't hurt.